### PR TITLE
a first attempt to use settings fixture instead of test_config one

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     install_requires=[
         "pytest>=2.7.0",
         "requests",
+        "dynaconf",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Hi Pino,
the main purpose of this PR is an attempt to start using dynaconf. It will be easy to configure tests using environmnent variables in case the tests are run in jenkins. It will be easy to add a dynaconf plugin to get properties from hashicorp vault too. Finally - dynaconf offers you to load properties from settings[toml,json,...] and .secrets[toml,json,...] so the origin function of json file to store properties will remain.