### PR TITLE
Switch to Dynaconf for the test configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__/
 .tox/
 build/
 env/
+
+# Ignore dynaconf secret files
+.secrets.*

--- a/pytest_client_tools/plugin.py
+++ b/pytest_client_tools/plugin.py
@@ -78,7 +78,7 @@ def _create_candlepin_container():
 
 @pytest.fixture(scope="session")
 def test_config(request):
-    return TestConfig(request.config.getoption("--test-config"))
+    return TestConfig()
 
 
 @pytest.fixture(scope="session")
@@ -196,9 +196,6 @@ def rhc(save_rhc_files, test_config):
 
 def pytest_addoption(parser):
     group = parser.getgroup("client-tools")
-    group.addoption(
-        "--test-config", action="store", type=pathlib.Path, help="custom test config"
-    )
     group.addoption(
         "--candlepin-container-is-running",
         action="store_true",

--- a/pytest_client_tools/test_config.py
+++ b/pytest_client_tools/test_config.py
@@ -5,7 +5,7 @@ from dynaconf import Dynaconf, Validator
 
 
 class TestConfig:
-    def __init__(self, test_config):
+    def __init__(self):
         self._settings = Dynaconf(
             envvar_prefix="PYTEST_CLIENT_TOOLS",
             settings_files=["settings.toml", ".secrets.toml"],

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "dataclasses;python_version<'3.7'",
+        "dynaconf",
         "pytest>=2.7.0",
         "requests",
     ],

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 dataclasses;python_version<"3.7"
+dynaconf
 flake8
 pytest
 requests


### PR DESCRIPTION
Adopt Dynaconf for the configuration for the test, replacing the custom code using json. This gives us a powerful configuration system to
- define & validate the configuration entries
- have multiple files to use and layer on top of each other, so secrets can be kept away

This also reworks `TestConfig.is_external`, by properly giving the meaning of "is an external Candlepin specified?".

Because of Dynaconf, the custom `--test-config` option for pytest is no more needed, and thus is dropped.