### PR TITLE
fix: removed explicit configuration for Dynaconf. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ and some helper bits:
 
 ## Configuration
 
-There is a fixture =test_config= in the defined fixtures.
+There is a fixture `test_config` in the defined fixtures.
 It uses [Dynaconf library](https://dynaconf.com) to load configuration
 properties.
 
 It is necesary to set a few env variables to tell dynaconf what
-properties source to use:
+source of the properties to use:
 
 ```bash
 export SETTINGS_FILES_FOR_DYNACONF="['settings.toml','.secrets.yaml']"
@@ -49,7 +49,7 @@ The example above specifies that dynaconf
 
 ### Environments in settings properties
 
-Dynaconf can provide you a different values of the properties
+Dynaconf can provide you different values of the properties
 depending on a specified environment (is it `ENV_FOR_DYNACONF`
 env variable).
 
@@ -59,19 +59,20 @@ an example of settings.yaml file:
 development:
   account:
     username: MY_NAME
-	password: MY_PASSWORD
+    password: MY_PASSWORD
 production:
   account:
     username: MY_PROD_NAME
-	password: MY_PROD_PASSWORD
+    password: MY_PROD_PASSWORD
 stage:
   account:
     username: MY_STAGE_NAME
-	password: MY_STAGE_PASSWORD
+    password: MY_STAGE_PASSWORD
 ```
 
-Specifying an env var `ENV_FOR_DYNACONF` you tell dynaconf to use the
-proper section to load properties.
+You will tell dynaconf to use the proper section to load properties 
+by specifying an env var `ENV_FOR_DYNACONF`.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,52 @@ and some helper bits:
 - `insights_client` -- `insights-client`
 - `rhc` -- `rhc`
 
+## Configuration
+
+There is a fixture =test_config= in the defined fixtures.
+It uses [Dynaconf library](https://dynaconf.com) to load configuration
+properties.
+
+It is necesary to set a few env variables to tell dynaconf what
+properties source to use:
+
+```bash
+export SETTINGS_FILES_FOR_DYNACONF="['settings.toml','.secrets.yaml']"
+export ENV_FOR_DYNACONF=stage
+```
+
+The default source of the properties to load is a shell environment.
+
+The example above specifies that dynaconf 
+- will load configuration from files `settings.toml` and `.secrets.yaml`
+- will use a section `stage` to load all properties.
+
+### Environments in settings properties
+
+Dynaconf can provide you a different values of the properties
+depending on a specified environment (is it `ENV_FOR_DYNACONF`
+env variable).
+
+an example of settings.yaml file:
+
+```yaml
+development:
+  account:
+    username: MY_NAME
+	password: MY_PASSWORD
+production:
+  account:
+    username: MY_PROD_NAME
+	password: MY_PROD_PASSWORD
+stage:
+  account:
+    username: MY_STAGE_NAME
+	password: MY_STAGE_PASSWORD
+```
+
+Specifying an env var `ENV_FOR_DYNACONF` you tell dynaconf to use the
+proper section to load properties.
+
 ## License
 
 Distributed under the terms of the `MIT`_ license.

--- a/pytest_client_tools/test_config.py
+++ b/pytest_client_tools/test_config.py
@@ -6,7 +6,9 @@ from dynaconf import Dynaconf, Validator
 
 class TestConfig:
     def __init__(self):
-        self._settings = Dynaconf()
+        self._settings = Dynaconf(
+            envvar_prefix = "PYTEST_CLIENT_TOOLS"
+        )
         self._settings.validators.register(
             Validator("candlepin.host"),
             Validator("candlepin.port", gt=0, lt=65536, cast=int, is_type_of=int),

--- a/pytest_client_tools/test_config.py
+++ b/pytest_client_tools/test_config.py
@@ -6,10 +6,7 @@ from dynaconf import Dynaconf, Validator
 
 class TestConfig:
     def __init__(self):
-        self._settings = Dynaconf(
-            envvar_prefix="PYTEST_CLIENT_TOOLS",
-            settings_files=["settings.toml", ".secrets.toml"],
-        )
+        self._settings = Dynaconf()
         self._settings.validators.register(
             Validator("candlepin.host"),
             Validator("candlepin.port", gt=0, lt=65536, cast=int, is_type_of=int),


### PR DESCRIPTION
I have removed explicit configuration for dynaconf.
I have updated README.md by a new section 'Configuration'.
There is an example how to configure Dynaconf in the section.