### PR TITLE
feat: adding POST to candlepin

### DIFF
--- a/pytest_client_tools/candlepin.py
+++ b/pytest_client_tools/candlepin.py
@@ -58,6 +58,12 @@ class Candlepin:
         """
         return self._rest_client.get(path, **kwargs)
 
+    def post(self, path, data, **kwargs):
+        """
+        Perform a POST REST call.
+        """
+        return self._rest_client.post(path, data, **kwargs)
+
     def status(self):
         """
         Get the status of the Candlepin server.

--- a/pytest_client_tools/restclient.py
+++ b/pytest_client_tools/restclient.py
@@ -57,3 +57,9 @@ class RestClient:
         Perform a GET REST call.
         """
         return self._request("GET", path, **kwargs)
+
+    def post(self, path, data, **kwargs):
+        """
+        Perform a POST REST call.
+        """
+        return self._request("POST", path, json=data, **kwargs)


### PR DESCRIPTION
Here I added a POST command so that we could test https://github.com/RedHatInsights/rhc/pull/121 

The container will reject POST in insecure mode so additional code was needed to perform REST calls validated against the container's cert.  I will assume that pre-existing candlepins will be already added to the system's ca-trust.

This is testable with something like:

``` python

import pytest

def test_candlepin_env(candlepin):
    env_uno = {"id": "env-id-1", "name": "env-name-1", "description": "Testing environment num. 1"}
    foo = candlepin.post('owners/donaldduck/environments', env_uno)
    assert foo.status_code == 200
    bar = candlepin.get(f"environments/{env_uno["id"]}")
    assert bar.json() == foo.json()
```

I added this as a unit test using pytester, and it passes, but I'm not sure how pytester works - it blows up after the test? Let me know if I should include that in this PR.
