### PR TITLE
feat:  Use candlepin container's cert for REST calls

### DIFF
--- a/pytest_client_tools/candlepin.py
+++ b/pytest_client_tools/candlepin.py
@@ -14,14 +14,14 @@ class Candlepin:
     This class represents a Candlepin server.
     """
 
-    def __init__(self, host, port, prefix, insecure):
+    def __init__(self, host, port, prefix, insecure, verify=False):
         self._host = host
         self._port = port
         self._prefix = prefix
         self._insecure = insecure
         self._rest_client = RestClient(
             base_url=f"https://{self._host}:{self._port}{self._prefix}",
-            verify=False,
+            verify=verify,
         )
 
     @property

--- a/pytest_client_tools/plugin.py
+++ b/pytest_client_tools/plugin.py
@@ -89,21 +89,26 @@ def test_config(request):
 
 
 @pytest.fixture(scope="session")
-def candlepin(request):
+def candlepin(request, tmp_path_factory):
     with contextlib.ExitStack() as stack:
         start_container = not request.config.getoption(
             "--candlepin-container-is-running"
         )
         initial_wait = 0
+        verify = False
         if start_container:
-            stack.enter_context(_create_candlepin_container())
+            container = stack.enter_context(_create_candlepin_container())
             # candlepin takes a while to start
             initial_wait = 5
+            ca_cert = str(tmp_path_factory.mktemp("candlepin") / "ca.crt")
+            container.cp("$C:/etc/candlepin/certs/candlepin-ca.crt", ca_cert)
+            verify = ca_cert
         candlepin = Candlepin(
             host="localhost",
             port=8443,
             prefix="/candlepin",
             insecure=True,
+            verify=verify,
         )
         ping_candlepin(candlepin, initial_wait=initial_wait)
         yield candlepin


### PR DESCRIPTION
This adds the candlepin container's cert for rest calls.

Saving this for other improvements. 