### PR TITLE
fix: Disabling check on return code for rhc is_registered property

### DIFF
--- a/pytest_client_tools/rhc.py
+++ b/pytest_client_tools/rhc.py
@@ -33,9 +33,11 @@ class Rhc:
         :return: Whether `rhc` is registered
         :rtype: bool
         """
-        proc = self.run("status", "--format", "json")
-        doc = json.loads(proc.stdout)
-        return doc["rhsm_connected"]
+        proc = self.run("status", "--format", "json", check=False)
+        if proc.returncode in [0, 1]:
+            doc = json.loads(proc.stdout)
+            return doc["rhsm_connected"]
+        proc.check_returncode()
 
     @property
     def version(self):


### PR DESCRIPTION
-rhc status command has been updated to return exit code 1 when
 system is not registered in newer version. Disabling the exit code
 check so that property can be used in both case.