### PR TITLE
fix: Adding Satellite hotfix for insights-client tests

### DIFF
--- a/pytest_client_tools/insights_client.py
+++ b/pytest_client_tools/insights_client.py
@@ -3,6 +3,7 @@
 
 import configparser
 import contextlib
+import os
 import pathlib
 import re
 import requests
@@ -381,7 +382,12 @@ class InsightsClient:
                 else "cert.cloud.redhat.com"
             )
         except (KeyError, AttributeError):
-            return "cert.cloud.redhat.com"
+            env_for_dynaconf = os.environ.get("ENV_FOR_DYNACONF", "")
+            return (
+                "cert.cloud.stage.redhat.com"
+                if env_for_dynaconf.startswith("satellite")
+                else "cert.cloud.redhat.com"
+            )
 
     def _get_inventory_id(self):
         """


### PR DESCRIPTION
I have added a Satellite option to _get_services_api_host which should fix the currently failing integration tests run on Satellite environments. As this is not the ideal solution but rather a hotfix I am leaving the comment about the method not being properly supported for Satellite.