### PR TITLE
Run tests using the specified version of python rather than platform python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,18 @@ jobs:
       - name: Install python3 and pip
         run: |
           dnf --setopt install_weak_deps=False install -y python${{ matrix.python-version }} python3-pip
-
-      - name: Install test requirements
-        run: pip install -r test-requirements.txt
-
-      - name: Run tests
+      
+      - name: Create venv
         run: |
-          pytest
+          python${{ matrix.python-version }} -m venv local_env
+      
+      - name: Enter venv and install test requirements
+        run: |
+          source ./local_env/bin/activate && pip install -r test-requirements.txt
+
+      - name: Enter venv and Run tests
+        run: |
+          source ./local_env/bin/activate && pytest
 
   install-test:
     name: "test as installed"


### PR DESCRIPTION
Prior to this PR the tests for pytest-client-tools were being run using that platform python version installed in whichever fedora container was specified rather than the version of python mentioned in the test matrix. This means we were unable to catch incompatibility with older versions of python for doing something like using the walrus operator (":=") on python 3.6.

Run the CI tests on branch 'csnyder/cct_1955_broken_example' by navigating to 'Actions' -> 'CI' (on the left) -> 'Run Workflow' (button on right) -> choose 'csnyder/cct_1955_broken_example` to see the fix in this branch along with a meaningless but syntactically correct usage of the walrus operator. This extra commit along with the fix in this branch correctly cause the python 3.6 part of the test matrix to fail.

You can also verify the behavior of this PR by looking at the CI workflow run on it and look in the logs for each part of the python test matrix logs, look at the step 'Run tests' and look just under the line '=== test session starts ==='. In this PR you'll see that the correct python version is used as specified.

Compare that to older automated runs of these tests, you'll see that all the tests were using the latest python in the container (for example the 3.6 tests were using 3.14).