### PR TITLE
HOTFIX: use http proxy every time when checking inventory and advisor

### DIFF
--- a/pytest_client_tools/insights_client.py
+++ b/pytest_client_tools/insights_client.py
@@ -412,6 +412,7 @@ class InsightsClient:
                 "/etc/pki/consumer/key.pem",
             ),
             timeout=60,
+            proxies={"https": "http://squid.corp.redhat.com:3128/"},
         )
         response.raise_for_status()
         return response.json()["id"]
@@ -462,6 +463,7 @@ class InsightsClient:
                     "/etc/pki/consumer/key.pem",
                 ),
                 timeout=60,
+                proxies={"https": "http://squid.corp.redhat.com:3128/"},
             )
             response.raise_for_status()
             return True


### PR DESCRIPTION
This is needed to access stage console.redhat.com