### PR TITLE
fix(rhc): Default to 'debug' log level

### DIFF
--- a/pytest_client_tools/plugin.py
+++ b/pytest_client_tools/plugin.py
@@ -276,7 +276,7 @@ def rhc(save_rhc_files, test_config):
                 "cannot load %s as TOML (skipping customizations): %s", config_file, e
             )
         else:
-            config["log-level"] = "trace"
+            config["log-level"] = "debug"
             with contextlib.suppress(KeyError):
                 rhc_server = test_config.get("rhc.server")
                 if rhc_server:


### PR DESCRIPTION
rhc used to use github.com/subpop/go-log logging library, and switched to log/slog semi-recently. The Go standard library does not define a TRACE log level, which made one test fail:

test_logging.py::test_log_connect_with_disabled_feature

This patch affects both yggdrasil and rhc. If any Yggdrasil test relies on the implicit behavior, it will have to be updated.